### PR TITLE
Add -noprofile flag for windows powershell to avoid permission issues

### DIFF
--- a/src/main/services/system-query/windows-system-query.service.ts
+++ b/src/main/services/system-query/windows-system-query.service.ts
@@ -213,7 +213,7 @@ export class WindowsSystemQueryService
                     description:
                         'Is the hard drive encryption enabled on the workstation?',
                     command:
-                        "powershell -command (New-Object -ComObject Shell.Application).NameSpace((Get-ChildItem Env:SystemDrive).Value).Self.ExtendedProperty('System.Volume.BitLockerProtection')",
+                        "powershell -noprofile -command (New-Object -ComObject Shell.Application).NameSpace((Get-ChildItem Env:SystemDrive).Value).Self.ExtendedProperty('System.Volume.BitLockerProtection')",
                     transform: async (res: any[]) =>
                         parseIntOrUndefined(res[0]),
                 }),


### PR DESCRIPTION
We recently had an issue with this hard drive encryption check on a developers windows machine that was using [powershell profiles](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_profiles?view=powershell-7.4).

In the `main.log` we found the following error on this command:
```
[error] <WindowsSystemQueryService>: . : File C:\Users\[UserName]\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1 cannot be loaded because 
its content could not be read.
At line:1 char:3
+ . 'C:\Users\[UserName]\Documents\WindowsPowerShell\Microsoft.Power ...
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : SecurityError: (:) [], PSSecurityException
    + FullyQualifiedErrorId : UnauthorizedAccess

its content could not be read.
At line:1 char:3
+ . 'C:\Users\[UserName]\Documents\WindowsPowerShell\Microsoft.Power ...
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : SecurityError: (:) [], PSSecurityException
    + FullyQualifiedErrorId : UnauthorizedAccess

    at C:\Users\[UserName]\AppData\Local\Programs\drata-agent\resources\app.asar\dist\main.js:2:1299642
    at ChildProcess.exithandler (node:child_process:422:7)
    at ChildProcess.emit (node:events:514:28)
    at maybeClose (node:internal/child_process:1091:16)
    at Process.onexit (node:internal/child_process:302:5)
```

As this command is just running a simple query the powershell scripts don't appear necessary so to avoid this issue for others in future this change just adds the [no profile](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_profiles?view=powershell-7.4#the-noprofile-parameter) flag to stop powershell attempting to load profiles on launch. 